### PR TITLE
Add obsidian-Auto-Tag-And-Reference plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5379,5 +5379,12 @@
         "author": "valteriomon",
         "repo": "valteriomon/obsidian-rapid-notes",
         "branch": "master"
+    },
+    {
+        "id": "obsidian-Auto-Tag-And-Reference",
+        "name": "Auto-Tag & Ref",
+        "author": "Luessiaw",
+        "description": "Auto tag/numbering an equation and refer to it like in latex.",
+        "repo": "Luessiaw/Obsidan-Auto-Tag-And-Reference"
     }
 ]


### PR DESCRIPTION
{
        "id": "obsidian-Auto-Tag-And-Reference",
        "name": "Auto-Tag & Ref",
        "author": "Luessiaw",
        "description": "Auto tag/numbering an equation and refer to it like in latex.",
        "repo": "Luessiaw/Obsidan-Auto-Tag-And-Reference"
    }

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
